### PR TITLE
fix(tawk): Prevent blank page when TAWK_SITE_ID is not configured

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,3 +56,12 @@ closing `</body>` tag in `resources/views/vendor/nova/layout.blade.php`:
 //      </body>
 // </html>
 ```
+
+## Troubleshooting
+
+### Blank page / Tawk widget not appearing
+1. **Check your `.env` values:** Ensure `TAWK_SITE_ID` and `TAWK_API_KEY` are set correctly. You can find these in your Tawk.to dashboard under Property Settings.
+2. **Clear config cache:** Run `php artisan config:clear` after updating `.env`.
+3. **Check the HTML source:** View your page source and look for the Tawk.to script tag. If it's missing entirely, the `@tawk` directive may not be in your layout. If it shows a comment about missing `TAWK_SITE_ID`, update your `.env`.
+4. **Check browser console:** Open the browser developer tools console for JavaScript errors.
+5. **Verify the directive placement:** The `@tawk` directive must be placed immediately before the closing `</body>` tag in your layout blade template.

--- a/resources/tawk.php
+++ b/resources/tawk.php
@@ -1,20 +1,24 @@
-        <script type="text/javascript">
+<?php if (config('services.tawk.site-id')) { ?>
+<script type="text/javascript">
             var Tawk_API=Tawk_API || {};
             var Tawk_LoadStart=new Date();
 
             <?php if (auth()->check()) { ?>
             Tawk_API.visitor = {
-                name  : '<?php echo auth()->user()->name ?>',
-                email : '<?php echo auth()->user()->email ?>',
+                name  : '<?php echo e(auth()->user()->name) ?>',
+                email : '<?php echo e(auth()->user()->email) ?>',
                 hash  : '<?php echo hash_hmac("sha256", auth()->user()->email, config("services.tawk.api-key")) ?>'
             };
             <?php } ?>
             (function(){
                 var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
                 s1.async=true;
-                s1.src='https://embed.tawk.to/<?php echo config("services.tawk.site-id") ?>/default';
+                s1.src='https://embed.tawk.to/<?php echo e(config("services.tawk.site-id")) ?>/default';
                 s1.charset='UTF-8';
                 s1.setAttribute('crossorigin','*');
                 s0.parentNode.insertBefore(s1,s0);
             })();
         </script>
+<?php } elseif (config('app.debug')) { ?>
+<!-- Tawk.to: TAWK_SITE_ID is not configured. Set TAWK_SITE_ID in your .env file. -->
+<?php } ?>


### PR DESCRIPTION
## Summary
Prevents a blank page when `TAWK_SITE_ID` is not configured. The `@tawk` Blade directive now guards against empty config, shows a helpful HTML comment in debug mode, and escapes user data to prevent XSS.

## Acceptance Criteria
- [x] Issue is resolved as described in the issue body
- [x] Existing functionality is not broken (no regressions)
- [x] Change is tested and documented if applicable

Fixes #4
