### PR TITLE
feat(screenshot): Capture page screenshot on chat start

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -5,5 +5,6 @@ return [
         "api-key" => env('TAWK_API_KEY'),
         "site-id" => env('TAWK_SITE_ID'),
         "capture-console" => env('TAWK_CAPTURE_CONSOLE', false),
+        "capture-screenshot" => env('TAWK_CAPTURE_SCREENSHOT', false),
     ]
 ];

--- a/config/services.php
+++ b/config/services.php
@@ -6,5 +6,6 @@ return [
         "site-id" => env('TAWK_SITE_ID'),
         "capture-console" => env('TAWK_CAPTURE_CONSOLE', false),
         "capture-screenshot" => env('TAWK_CAPTURE_SCREENSHOT', false),
+        "html2canvas-url" => env('TAWK_HTML2CANVAS_URL', 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js'),
     ]
 ];

--- a/readme.md
+++ b/readme.md
@@ -79,3 +79,12 @@ When enabled, the last 50 console entries are captured and sent as custom attrib
 
 The data appears in the Tawk.to agent dashboard as custom visitor attributes.
 
+### Screenshot Capture
+To automatically take a screenshot of the page when a visitor starts a chat, add the following to your `.env`:
+```
+TAWK_CAPTURE_SCREENSHOT=true
+```
+
+When enabled, html2canvas (loaded from CDN) captures the visible page and sends it as a Tawk.to custom attribute. The screenshot appears in the agent dashboard as a base64 JPEG image.
+
+**Note:** Screenshots are compressed (50% scale, 60% JPEG quality) to stay within Tawk.to's attribute size limits. Very large pages may exceed the limit and the screenshot will be skipped.

--- a/resources/js/tawk-console-capture.js
+++ b/resources/js/tawk-console-capture.js
@@ -59,7 +59,11 @@
 
     // Send console logs when Tawk chat starts
     if (typeof Tawk_API !== 'undefined') {
+        var previousOnChatStarted = Tawk_API.onChatStarted;
         Tawk_API.onChatStarted = function() {
+            if (typeof previousOnChatStarted === 'function') {
+                previousOnChatStarted();
+            }
             if (consoleLogs.length === 0) return;
 
             var errors = consoleLogs.filter(function(l) { return l.level === 'error'; });

--- a/resources/js/tawk-screenshot.js
+++ b/resources/js/tawk-screenshot.js
@@ -11,10 +11,17 @@
 (function() {
     var html2canvasReady = false;
 
-    // Load html2canvas from CDN
+    // Load html2canvas from CDN (URL configurable via TAWK_HTML2CANVAS_URL)
+    var cdnUrl = (typeof tawkHtml2canvasUrl !== 'undefined' && tawkHtml2canvasUrl)
+        ? tawkHtml2canvasUrl
+        : 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
+    var isDefaultCdn = cdnUrl.indexOf('cdnjs.cloudflare.com') !== -1;
+
     var script = document.createElement('script');
-    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
-    script.integrity = 'sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoFM/HPeLTC2BbQG0e2LOKKL7lXIA==';
+    script.src = cdnUrl;
+    if (isDefaultCdn) {
+        script.integrity = 'sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoFM/HPeLTC2BbQG0e2LOKKL7lXIA==';
+    }
     script.crossOrigin = 'anonymous';
     script.referrerPolicy = 'no-referrer';
     script.onload = function() {
@@ -49,7 +56,11 @@
     }
 
     if (typeof Tawk_API !== 'undefined') {
+        var previousOnChatStarted = Tawk_API.onChatStarted;
         Tawk_API.onChatStarted = function() {
+            if (typeof previousOnChatStarted === 'function') {
+                previousOnChatStarted();
+            }
             captureScreenshot(function(dataUrl) {
                 if (!dataUrl) return;
 

--- a/resources/js/tawk-screenshot.js
+++ b/resources/js/tawk-screenshot.js
@@ -1,0 +1,68 @@
+/**
+ * Tawk.to Screenshot Capture
+ *
+ * Takes a screenshot of the page using html2canvas when a chat starts
+ * and sends it as a Tawk.to event/attribute.
+ *
+ * Enable via config: TAWK_CAPTURE_SCREENSHOT=true
+ *
+ * Requires html2canvas loaded on the page (loaded from CDN automatically).
+ */
+(function() {
+    // Load html2canvas from CDN
+    var script = document.createElement('script');
+    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
+    script.integrity = 'sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoFM/HPeLTC2BbQG0e2LOKKL7lXIA==';
+    script.crossOrigin = 'anonymous';
+    script.referrerPolicy = 'no-referrer';
+    document.head.appendChild(script);
+
+    function captureScreenshot(callback) {
+        if (typeof html2canvas === 'undefined') {
+            callback(null);
+            return;
+        }
+
+        try {
+            html2canvas(document.body, {
+                logging: false,
+                useCORS: true,
+                scale: 0.5,
+                width: window.innerWidth,
+                height: window.innerHeight,
+                windowWidth: window.innerWidth,
+                windowHeight: window.innerHeight,
+            }).then(function(canvas) {
+                var dataUrl = canvas.toDataURL('image/jpeg', 0.6);
+                callback(dataUrl);
+            }).catch(function() {
+                callback(null);
+            });
+        } catch(e) {
+            callback(null);
+        }
+    }
+
+    if (typeof Tawk_API !== 'undefined') {
+        Tawk_API.onChatStarted = function() {
+            captureScreenshot(function(dataUrl) {
+                if (!dataUrl) return;
+
+                // Send as custom attribute (truncated if too long for Tawk limits)
+                // Tawk custom attributes have a ~32KB limit
+                if (dataUrl.length < 32000) {
+                    Tawk_API.setAttributes({
+                        'page-screenshot': dataUrl
+                    }, function(error) {});
+                }
+
+                // Also send as an event with page info
+                Tawk_API.addEvent('screenshot-captured', {
+                    url: window.location.href,
+                    viewport: window.innerWidth + 'x' + window.innerHeight,
+                    timestamp: new Date().toISOString()
+                }, function(error) {});
+            });
+        };
+    }
+})();

--- a/resources/js/tawk-screenshot.js
+++ b/resources/js/tawk-screenshot.js
@@ -9,16 +9,21 @@
  * Requires html2canvas loaded on the page (loaded from CDN automatically).
  */
 (function() {
+    var html2canvasReady = false;
+
     // Load html2canvas from CDN
     var script = document.createElement('script');
     script.src = 'https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js';
     script.integrity = 'sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoFM/HPeLTC2BbQG0e2LOKKL7lXIA==';
     script.crossOrigin = 'anonymous';
     script.referrerPolicy = 'no-referrer';
+    script.onload = function() {
+        html2canvasReady = true;
+    };
     document.head.appendChild(script);
 
     function captureScreenshot(callback) {
-        if (typeof html2canvas === 'undefined') {
+        if (!html2canvasReady || typeof html2canvas === 'undefined') {
             callback(null);
             return;
         }

--- a/resources/tawk.php
+++ b/resources/tawk.php
@@ -26,6 +26,7 @@
 <?php } ?>
 <?php if (config('services.tawk.capture-screenshot') && file_exists(__DIR__ . '/js/tawk-screenshot.js')) { ?>
 <script type="text/javascript">
+var tawkHtml2canvasUrl = '<?php echo e(config("services.tawk.html2canvas-url")); ?>';
 <?php echo file_get_contents(__DIR__ . '/js/tawk-screenshot.js'); ?>
 </script>
 <?php } ?>

--- a/resources/tawk.php
+++ b/resources/tawk.php
@@ -24,6 +24,11 @@
 <?php echo file_get_contents(__DIR__ . '/js/tawk-console-capture.js'); ?>
 </script>
 <?php } ?>
+<?php if (config('services.tawk.capture-screenshot')) { ?>
+<script type="text/javascript">
+<?php echo file_get_contents(__DIR__ . '/js/tawk-screenshot.js'); ?>
+</script>
+<?php } ?>
 <?php } elseif (config('app.debug')) { ?>
 <!-- Tawk.to: TAWK_SITE_ID is not configured. Set TAWK_SITE_ID in your .env file. -->
 <?php } ?>

--- a/resources/tawk.php
+++ b/resources/tawk.php
@@ -19,12 +19,12 @@
                 s0.parentNode.insertBefore(s1,s0);
             })();
         </script>
-<?php if (config('services.tawk.capture-console')) { ?>
+<?php if (config('services.tawk.capture-console') && file_exists(__DIR__ . '/js/tawk-console-capture.js')) { ?>
 <script type="text/javascript">
 <?php echo file_get_contents(__DIR__ . '/js/tawk-console-capture.js'); ?>
 </script>
 <?php } ?>
-<?php if (config('services.tawk.capture-screenshot')) { ?>
+<?php if (config('services.tawk.capture-screenshot') && file_exists(__DIR__ . '/js/tawk-screenshot.js')) { ?>
 <script type="text/javascript">
 <?php echo file_get_contents(__DIR__ . '/js/tawk-screenshot.js'); ?>
 </script>

--- a/src/Providers/Service.php
+++ b/src/Providers/Service.php
@@ -11,9 +11,13 @@ class Service extends ServiceProvider
 
     public function boot()
     {
+        $resourcePath = realpath(__DIR__ . "/../../resources");
+
         $this->app->make(BladeCompiler::class)
-            ->directive("tawk", function () {
-                return file_get_contents(__DIR__ . "/../../resources/tawk.php");
+            ->directive("tawk", function () use ($resourcePath) {
+                $template = file_get_contents($resourcePath . "/tawk.php");
+
+                return str_replace('__DIR__', "'" . addslashes($resourcePath) . "'", $template);
             });
     }
 

--- a/tests/ConsoleCaptureTest.php
+++ b/tests/ConsoleCaptureTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace GeneaLabs\LaravelTawk\Tests;
+
+use GeneaLabs\LaravelTawk\Providers\Service;
+use Illuminate\Support\Facades\Blade;
+use Orchestra\Testbench\TestCase;
+
+class ConsoleCaptureTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [Service::class];
+    }
+
+    protected function renderTawkDirective(): string
+    {
+        return Blade::render('@tawk');
+    }
+
+    public function test_console_capture_uses_callback_chaining(): void
+    {
+        config([
+            'services.tawk.site-id' => 'test-site-id',
+            'services.tawk.capture-console' => true,
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertStringContainsString('previousOnChatStarted', $output);
+    }
+
+    public function test_screenshot_uses_callback_chaining(): void
+    {
+        config([
+            'services.tawk.site-id' => 'test-site-id',
+            'services.tawk.capture-screenshot' => true,
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertStringContainsString('previousOnChatStarted', $output);
+    }
+
+    public function test_both_features_enabled_includes_chaining_in_both(): void
+    {
+        config([
+            'services.tawk.site-id' => 'test-site-id',
+            'services.tawk.capture-console' => true,
+            'services.tawk.capture-screenshot' => true,
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertGreaterThanOrEqual(
+            2,
+            substr_count($output, 'previousOnChatStarted'),
+            'Both console and screenshot scripts should chain the onChatStarted callback'
+        );
+    }
+}

--- a/tests/ScreenshotFeatureTest.php
+++ b/tests/ScreenshotFeatureTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace GeneaLabs\LaravelTawk\Tests;
+
+use GeneaLabs\LaravelTawk\Providers\Service;
+use Illuminate\Support\Facades\Blade;
+use Orchestra\Testbench\TestCase;
+
+class ScreenshotFeatureTest extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [Service::class];
+    }
+
+    protected function renderTawkDirective(): string
+    {
+        return Blade::render('@tawk');
+    }
+
+    public function test_capture_screenshot_config_key_exists_and_defaults_to_false(): void
+    {
+        $this->assertFalse(config('services.tawk.capture-screenshot'));
+    }
+
+    public function test_html2canvas_url_config_key_exists_with_default(): void
+    {
+        $this->assertNotNull(config('services.tawk.html2canvas-url'));
+        $this->assertStringContainsString('html2canvas', config('services.tawk.html2canvas-url'));
+    }
+
+    public function test_directive_includes_screenshot_js_when_enabled(): void
+    {
+        config([
+            'services.tawk.site-id' => 'test-site-id',
+            'services.tawk.capture-screenshot' => true,
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertStringContainsString('captureScreenshot', $output);
+        $this->assertStringContainsString('html2canvas', $output);
+        $this->assertStringContainsString('tawkHtml2canvasUrl', $output);
+    }
+
+    public function test_directive_excludes_screenshot_js_when_disabled(): void
+    {
+        config([
+            'services.tawk.site-id' => 'test-site-id',
+            'services.tawk.capture-screenshot' => false,
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertStringNotContainsString('captureScreenshot', $output);
+    }
+
+    public function test_directive_excludes_screenshot_js_when_no_site_id(): void
+    {
+        config([
+            'services.tawk.site-id' => null,
+            'services.tawk.capture-screenshot' => true,
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertStringNotContainsString('captureScreenshot', $output);
+    }
+
+    public function test_custom_html2canvas_url_is_injected_into_output(): void
+    {
+        config([
+            'services.tawk.site-id' => 'test-site-id',
+            'services.tawk.capture-screenshot' => true,
+            'services.tawk.html2canvas-url' => 'https://custom-cdn.example.com/html2canvas.min.js',
+        ]);
+
+        $output = $this->renderTawkDirective();
+
+        $this->assertStringContainsString('custom-cdn.example.com', $output);
+    }
+}


### PR DESCRIPTION
## Summary
Captures a page screenshot using html2canvas when a visitor starts a Tawk.to chat. The screenshot is sent as a custom attribute for the support agent to see. Opt-in via `TAWK_CAPTURE_SCREENSHOT=true`.

## Changes
- Fixed `onChatStarted` callback clobbering — both console-capture and screenshot scripts now chain the previous handler instead of overwriting it
- Made html2canvas CDN URL configurable via `TAWK_HTML2CANVAS_URL` env var (defaults to cdnjs); SRI hash applied only when using the default CDN
- Fixed `__DIR__` resolution bug in compiled Blade templates — the directive now injects the resolved resource path at compile time
- Injected `tawkHtml2canvasUrl` variable into the rendered output so the JS picks up the configured URL
- Added test suites for screenshot feature and console capture callback chaining

## Acceptance Criteria
- [x] Issue is resolved as described in the issue body
- [x] Existing functionality is not broken (no regressions)
- [x] Change is tested and documented if applicable

## Test Coverage
- `ScreenshotFeatureTest` (6 tests): config defaults, JS inclusion/exclusion based on config, custom CDN URL injection
- `ConsoleCaptureTest` (3 tests): callback chaining for console, screenshot, and both features together

Fixes #2
